### PR TITLE
Add capability to protect passwords with argon2i. Make it default too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Phaas is study/attempt to help with those issues by creating small http api that
 
 # example of environment configuration that will initialize phaas user database with user "testing-user", and makes user database immutable
 
-db.users.content = [{"userDTO":{"id":null,"userName":"testing-user","passwordHash":"$2a$10$8jH2j2uTf5AEXanJhiFvu.6sS.IDUB25AOqGIeYBwrOlFqe8XAHJm","roles":"ROLE_USER","sharedSecretForSigningCommunication":"secret"},"userConfigurationDTOs":[{"id":null,"user":"testing-user","dataProtectionKey":"da5385256044cfa6.b6c628d3bc92b404c4f7735e52cf80dbd6ad88fbece0a42f564e13d75607d922fd2231d9f309428430dffb1fdb00cf52cd5b080811d866757676509dba50ca77","active":true,"algorithm":"SHA256_BCRYPT"}]}]
+db.users.content = [{"userDTO":{"id":null,"userName":"testing-user","passwordHash":"$argon2i$v=19$m=65536,t=2,p=1$3e8ro44yaQU6YEGER61Scw$VprNapX493KBjNA51NDsKbzO3ZSrWWcpguBntjkHmRo","roles":"ROLE_USER","sharedSecretForSigningCommunication":"secret"},"userConfigurationDTOs":[{"id":null,"user":"testing-user","dataProtectionKey":"fc467f7b2ba1f3aa.4c0e6e3cc106645148deb44305df422386fbd861e6418d99f2b3d434c83736ad712816ebac2fdcd407f65d2f97703016be00a41b042d61b1de36e212837a29fa","active":true,"algorithm":"ARGON2"}]}]
 immutable.users.db = true
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>4.23</version>
         </dependency>
+        <dependency>
+            <groupId>de.mkammerer</groupId>
+            <artifactId>argon2-jvm</artifactId>
+            <version>2.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/tomitakussaari/phaas/GracefullyStopTomcat.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/GracefullyStopTomcat.java
@@ -32,7 +32,7 @@ public class GracefullyStopTomcat {
     }
 
     @Slf4j
-    private static class GracefulShutdown implements ApplicationListener<ContextClosedEvent>, TomcatConnectorCustomizer {
+    static class GracefulShutdown implements ApplicationListener<ContextClosedEvent>, TomcatConnectorCustomizer {
 
         private Connector connector;
 

--- a/src/main/java/com/github/tomitakussaari/phaas/api/DataProtectionApi.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/api/DataProtectionApi.java
@@ -1,9 +1,9 @@
 package com.github.tomitakussaari.phaas.api;
 
 
-import com.github.tomitakussaari.phaas.model.JWT.JwtCreateRequest;
-import com.github.tomitakussaari.phaas.model.JWT.JwtParseRequest;
-import com.github.tomitakussaari.phaas.user.PhaasUserDetails;
+import com.github.tomitakussaari.phaas.model.Tokens.CreateTokenRequest;
+import com.github.tomitakussaari.phaas.model.Tokens.ParseTokenRequest;
+import com.github.tomitakussaari.phaas.user.PhaasUser;
 import com.github.tomitakussaari.phaas.util.JwtHelper;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,15 +20,17 @@ import java.util.Map;
 @RequestMapping("/data-protection")
 public class DataProtectionApi {
 
+    private final JwtHelper jwtHelper = new JwtHelper();
+
     @ApiOperation(value = "Creates token with given claims (jwt)", consumes = "application/json")
     @RequestMapping(method = RequestMethod.POST, path = "/token")
-    public String generateJWT(@RequestBody JwtCreateRequest createRequest, @ApiIgnore @AuthenticationPrincipal PhaasUserDetails userDetails) {
-        return JwtHelper.generate(userDetails, createRequest.getClaims());
+    public String generateJWT(@RequestBody CreateTokenRequest createRequest, @ApiIgnore @AuthenticationPrincipal PhaasUser userDetails) {
+        return jwtHelper.generate(userDetails, createRequest.getClaims());
     }
 
     @ApiOperation(value = "Verifies token and returns claims (jwt)", consumes = "application/json")
     @RequestMapping(method = RequestMethod.PUT, path = "/token")
-    public Map<String, Object> parseJwt(@RequestBody JwtParseRequest parseRequest, @ApiIgnore @AuthenticationPrincipal PhaasUserDetails userDetails) {
-        return JwtHelper.verifyAndGetClaims(userDetails, parseRequest.getToken(), parseRequest.getRequiredClaims().orElseGet(() -> Collections.EMPTY_MAP));
+    public Map<String, Object> parseJwt(@RequestBody ParseTokenRequest parseRequest, @ApiIgnore @AuthenticationPrincipal PhaasUser userDetails) {
+        return jwtHelper.verifyAndGetClaims(userDetails, parseRequest.getToken(), parseRequest.getRequiredClaims().orElseGet(() -> Collections.EMPTY_MAP));
     }
 }

--- a/src/main/java/com/github/tomitakussaari/phaas/api/PasswordApi.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/api/PasswordApi.java
@@ -5,7 +5,7 @@ import com.github.tomitakussaari.phaas.model.PasswordHashRequest;
 import com.github.tomitakussaari.phaas.model.PasswordVerifyRequest;
 import com.github.tomitakussaari.phaas.model.PasswordVerifyResult;
 import com.github.tomitakussaari.phaas.user.UsersService;
-import com.github.tomitakussaari.phaas.user.PhaasUserDetails;
+import com.github.tomitakussaari.phaas.user.PhaasUser;
 import com.github.tomitakussaari.phaas.util.PasswordHasher;
 import com.github.tomitakussaari.phaas.util.PasswordVerifier;
 import io.swagger.annotations.ApiOperation;
@@ -33,7 +33,7 @@ public class PasswordApi {
     @ApiOperation(value = "Protects password and returns hash from it")
     @Secured({UsersService.USER_ROLE_VALUE})
     @RequestMapping(method = RequestMethod.PUT, path = "/hash", produces = "application/json")
-    public HashedPassword hashPassword(@RequestBody PasswordHashRequest request, @ApiIgnore @AuthenticationPrincipal PhaasUserDetails userDetails) {
+    public HashedPassword hashPassword(@RequestBody PasswordHashRequest request, @ApiIgnore @AuthenticationPrincipal PhaasUser userDetails) {
         return passwordHasher.hash(request, userDetails.currentlyActiveCryptoData());
     }
 
@@ -44,7 +44,7 @@ public class PasswordApi {
             @ApiResponse(code = 422, message = "Password was not valid")
     })
     @RequestMapping(method = RequestMethod.PUT, path = "/verify", produces = "application/json")
-    public ResponseEntity<PasswordVerifyResult> verifyPassword(@RequestBody PasswordVerifyRequest request, @ApiIgnore @AuthenticationPrincipal PhaasUserDetails userDetails) {
+    public ResponseEntity<PasswordVerifyResult> verifyPassword(@RequestBody PasswordVerifyRequest request, @ApiIgnore @AuthenticationPrincipal PhaasUser userDetails) {
         PasswordVerifyResult result = passwordVerifier.verify(request, userDetails.cryptoDataForId(request.schemeId()), userDetails.currentlyActiveCryptoData());
         return result.isValid() ? ResponseEntity.ok(result) : ResponseEntity.unprocessableEntity().body(result);
     }

--- a/src/main/java/com/github/tomitakussaari/phaas/api/UsersApi.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/api/UsersApi.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.github.tomitakussaari.phaas.model.DataProtectionScheme;
 import com.github.tomitakussaari.phaas.model.PasswordEncodingAlgorithm;
 import com.github.tomitakussaari.phaas.user.UsersService;
-import com.github.tomitakussaari.phaas.user.PhaasUserDetails;
+import com.github.tomitakussaari.phaas.user.PhaasUser;
 import io.swagger.annotations.ApiOperation;
 import lombok.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,14 +31,14 @@ public class UsersApi {
     @ApiOperation(value = "Returns information about current user")
     @Secured({UsersService.USER_ROLE_VALUE})
     @RequestMapping(method = RequestMethod.GET, produces = "application/json", path = "/me")
-    public PublicUser whoAmI(@ApiIgnore @AuthenticationPrincipal PhaasUserDetails userDetails) {
+    public PublicUser whoAmI(@ApiIgnore @AuthenticationPrincipal PhaasUser userDetails) {
         return toPublicUser(userDetails);
     }
 
     @ApiOperation(value = "Changes user password.")
     @Secured({UsersService.USER_ROLE_VALUE})
     @RequestMapping(method = RequestMethod.PUT, produces = "application/json", path = "/me")
-    public void changePassword(@RequestBody NewPasswordRequest newPasswordRequest, @ApiIgnore @AuthenticationPrincipal PhaasUserDetails userDetails) {
+    public void changePassword(@RequestBody NewPasswordRequest newPasswordRequest, @ApiIgnore @AuthenticationPrincipal PhaasUser userDetails) {
         rejectIfUserDatabaseIsImmutable();
         usersService.changePasswordAndSecret(userDetails.getUsername(), newPasswordRequest.getPassword(), userDetails.findCurrentUserPassword(), newPasswordRequest.getSharedSecretForSigningCommunication());
     }
@@ -68,12 +68,12 @@ public class UsersApi {
 
     @ApiOperation(value = "Creates new protectionscheme and makes it active")
     @RequestMapping(method = RequestMethod.POST, path = "/me/scheme", consumes = "application/json")
-    public void newProtectionScheme(@RequestBody ProtectionSchemeRequest request, @ApiIgnore @AuthenticationPrincipal PhaasUserDetails userDetails) {
+    public void newProtectionScheme(@RequestBody ProtectionSchemeRequest request, @ApiIgnore @AuthenticationPrincipal PhaasUser userDetails) {
         rejectIfUserDatabaseIsImmutable();
         usersService.newProtectionScheme(userDetails.getUsername(), request.getAlgorithm(), userDetails.findCurrentUserPassword(), request.isRemoveOldSchemes());
     }
 
-    private PublicUser toPublicUser(PhaasUserDetails userDetails) {
+    private PublicUser toPublicUser(PhaasUser userDetails) {
         return PublicUser.builder()
                 .userName(userDetails.getUsername())
                 .currentProtectionScheme(userDetails.activeProtectionScheme().toPublicScheme())

--- a/src/main/java/com/github/tomitakussaari/phaas/model/DataProtectionScheme.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/model/DataProtectionScheme.java
@@ -27,7 +27,7 @@ public class DataProtectionScheme {
         return new PublicProtectionScheme(id, algorithm);
     }
 
-    public CryptoData decryptedProtectionScheme(CharSequence userPassword) {
+    public CryptoData cryptoData(CharSequence userPassword) {
         return new CryptoData(this, userPassword);
     }
 

--- a/src/main/java/com/github/tomitakussaari/phaas/model/PasswordEncodingAlgorithm.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/model/PasswordEncodingAlgorithm.java
@@ -1,30 +1,61 @@
 package com.github.tomitakussaari.phaas.model;
 
 import com.google.common.hash.Hashing;
+import de.mkammerer.argon2.Argon2;
+import de.mkammerer.argon2.Argon2Constants;
+import de.mkammerer.argon2.Argon2Factory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public enum PasswordEncodingAlgorithm {
-    SHA256_BCRYPT(SHA256AndBCryptPasswordEncoder::new);
+    ARGON2("$argon2i$", Argon2PasswordEncoder::new),
+    SHA256_BCRYPT("$2a$", SHA256AndBCryptPasswordEncoder::new);
 
-    private final Supplier<PasswordEncoder> supplier;
+    private final String hashPrefix;
+    private final Supplier<PasswordEncoder> encoderSupplier;
 
-    PasswordEncodingAlgorithm(Supplier<PasswordEncoder> supplier) {
-        this.supplier = supplier;
+    PasswordEncodingAlgorithm(String hashPrefix, Supplier<PasswordEncoder> encoderSupplier) {
+        this.hashPrefix = hashPrefix;
+        this.encoderSupplier = encoderSupplier;
     }
 
     public PasswordEncoder encoder() {
-        return supplier.get();
+        return encoderSupplier.get();
+    }
+
+    public static Optional<PasswordEncodingAlgorithm> findForHash(String hash) {
+        for(PasswordEncodingAlgorithm algorithm : values()) {
+            if(hash.startsWith(algorithm.hashPrefix)) {
+                return Optional.of(algorithm);
+            }
+        }
+        return Optional.empty();
+    }
+}
+
+class Argon2PasswordEncoder implements PasswordEncoder {
+
+    private final Argon2 argon2 = Argon2Factory.create(Argon2Factory.Argon2Types.ARGON2i, Argon2Constants.DEFAULT_SALT_LENGTH, Argon2Constants.DEFAULT_HASH_LENGTH);
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return argon2.hash(2, 65536, 1, rawPassword.toString(), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return argon2.verify(encodedPassword, rawPassword.toString(), StandardCharsets.UTF_8);
     }
 }
 
 class SHA256AndBCryptPasswordEncoder extends BCryptPasswordEncoder {
 
     SHA256AndBCryptPasswordEncoder() {
-        super(12);
+        super(11);
     }
 
     @Override

--- a/src/main/java/com/github/tomitakussaari/phaas/model/Tokens.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/model/Tokens.java
@@ -9,18 +9,18 @@ import java.util.Map;
 import java.util.Optional;
 
 @UtilityClass
-public class JWT {
+public class Tokens {
 
     @RequiredArgsConstructor
     @Getter
-    public static class JwtCreateRequest {
+    public static class CreateTokenRequest {
         @NonNull
         private final Map<String, Object> claims;
     }
 
     @RequiredArgsConstructor
     @Getter
-    public static class JwtParseRequest {
+    public static class ParseTokenRequest {
         @NonNull
         private final String token;
         @NonNull

--- a/src/main/java/com/github/tomitakussaari/phaas/user/PhaasUser.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/user/PhaasUser.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static java.util.stream.Collectors.toList;
 
 @RequiredArgsConstructor
-public class PhaasUserDetails implements UserDetails {
+public class PhaasUser implements UserDetails {
 
     private final UserDTO userDTO;
     private final List<UserConfigurationDTO> configurations;
@@ -47,11 +47,11 @@ public class PhaasUserDetails implements UserDetails {
     }
 
     public CryptoData currentlyActiveCryptoData() {
-        return activeProtectionScheme().decryptedProtectionScheme(findCurrentUserPassword());
+        return activeProtectionScheme().cryptoData(findCurrentUserPassword());
     }
 
     public CryptoData cryptoDataForId(int schemeId) {
-        return protectionScheme(schemeId).decryptedProtectionScheme(findCurrentUserPassword());
+        return protectionScheme(schemeId).cryptoData(findCurrentUserPassword());
     }
 
     @Override

--- a/src/main/java/com/github/tomitakussaari/phaas/user/UserPasswordEncoder.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/user/UserPasswordEncoder.java
@@ -1,0 +1,20 @@
+package com.github.tomitakussaari.phaas.user;
+
+import com.github.tomitakussaari.phaas.model.PasswordEncodingAlgorithm;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class UserPasswordEncoder implements PasswordEncoder {
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return PasswordEncodingAlgorithm.ARGON2.encoder().encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return PasswordEncodingAlgorithm.findForHash(encodedPassword)
+                .map(PasswordEncodingAlgorithm::encoder)
+                .map(passwordEncoder -> passwordEncoder.matches(rawPassword, encodedPassword))
+                .orElse(false);
+    }
+}

--- a/src/main/java/com/github/tomitakussaari/phaas/util/JsonHelper.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/util/JsonHelper.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 import java.io.IOException;
 
-public abstract class JsonHelper {
+public class JsonHelper {
 
     public static final ObjectMapper objectMapper = new ObjectMapper()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
@@ -20,16 +20,16 @@ public abstract class JsonHelper {
             .registerModule(new ParameterNamesModule())
             .registerModule(new AfterburnerModule());
 
-    public static String serialize(Object input) {
-        return objectMapSafely(() -> objectMapper.writeValueAsString(input));
-    }
-
     public static <T> T objectMapSafely(ObjectMapperOperation<T> objectMapperOperation) {
         try {
             return objectMapperOperation.get();
         } catch (IOException e) {
             throw new UnsupportedOperationException("JSON serialization does not work ?", e);
         }
+    }
+
+    public String serialize(Object input) {
+        return objectMapSafely(() -> objectMapper.writeValueAsString(input));
     }
 
     @FunctionalInterface

--- a/src/main/java/com/github/tomitakussaari/phaas/util/JwtHelper.java
+++ b/src/main/java/com/github/tomitakussaari/phaas/util/JwtHelper.java
@@ -1,7 +1,7 @@
 package com.github.tomitakussaari.phaas.util;
 
 import com.github.tomitakussaari.phaas.model.DataProtectionScheme.CryptoData;
-import com.github.tomitakussaari.phaas.user.PhaasUserDetails;
+import com.github.tomitakussaari.phaas.user.PhaasUser;
 import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.DirectDecrypter;
 import com.nimbusds.jose.crypto.DirectEncrypter;
@@ -9,7 +9,6 @@ import com.nimbusds.jose.crypto.MACSigner;
 import com.nimbusds.jose.crypto.MACVerifier;
 import com.nimbusds.jwt.JWTClaimsSet.Builder;
 import com.nimbusds.jwt.SignedJWT;
-import lombok.experimental.UtilityClass;
 
 import java.text.ParseException;
 import java.util.Date;
@@ -18,35 +17,7 @@ import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-@UtilityClass
 public class JwtHelper {
-
-    public static String generate(PhaasUserDetails userDetails, Map<String, Object> claims) {
-        try {
-            CryptoData cryptoData = userDetails.currentlyActiveCryptoData();
-
-            Builder claimSetBuilder = new Builder().jwtID(UUID.randomUUID().toString()).issueTime(new Date()).issuer(userDetails.getUsername());
-
-            claims.forEach(claimSetBuilder::claim);
-
-            return encrypt(cryptoData, signedToken(cryptoData, claimSetBuilder)).serialize();
-        } catch (JOSEException e) {
-            throw new JWTException(e);
-        }
-    }
-
-    public static Map<String, Object> verifyAndGetClaims(PhaasUserDetails userDetails, String token, Map<String, Object> requiredClaims) {
-        try {
-            JWEObject jweObject = JWEObject.parse(token);
-            CryptoData cryptoData = findCryptoData(userDetails, jweObject);
-
-            Map<String, Object> actualClaims = decryptAndVerifySignature(jweObject, cryptoData).getJWTClaimsSet().getClaims();
-
-            return verifyClaims(requiredClaims, actualClaims);
-        } catch (JOSEException | ParseException | IllegalArgumentException e) {
-            throw new JWTException(e);
-        }
-    }
 
     private static SignedJWT decryptAndVerifySignature(JWEObject jweObject, CryptoData cryptoData) throws JOSEException {
         jweObject.decrypt(new DirectDecrypter(cryptoData.dataProtectionKey().getBytes()));
@@ -55,7 +26,7 @@ public class JwtHelper {
         return signedJWT;
     }
 
-    private static CryptoData findCryptoData(PhaasUserDetails userDetails, JWEObject jweObject) {
+    private static CryptoData findCryptoData(PhaasUser userDetails, JWEObject jweObject) {
         Integer schemeId = Integer.valueOf(jweObject.getHeader().getKeyID());
         return userDetails.cryptoDataForId(schemeId);
     }
@@ -81,13 +52,39 @@ public class JwtHelper {
                 new JWEHeader.Builder(JWEAlgorithm.DIR, EncryptionMethod.A256GCM)
                         .keyID(String.valueOf(cryptoData.getScheme().getId()))
                         .compressionAlgorithm(CompressionAlgorithm.DEF)
-                        .contentType("JWT")
+                        .contentType("Tokens")
                         .build(),
                 new Payload(signedJWT));
         jweObject.encrypt(new DirectEncrypter(cryptoData.dataProtectionKey().getBytes()));
         return jweObject;
     }
 
+    public String generate(PhaasUser userDetails, Map<String, Object> claims) {
+        try {
+            CryptoData cryptoData = userDetails.currentlyActiveCryptoData();
+
+            Builder claimSetBuilder = new Builder().jwtID(UUID.randomUUID().toString()).issueTime(new Date()).issuer(userDetails.getUsername());
+
+            claims.forEach(claimSetBuilder::claim);
+
+            return encrypt(cryptoData, signedToken(cryptoData, claimSetBuilder)).serialize();
+        } catch (JOSEException e) {
+            throw new JWTException(e);
+        }
+    }
+
+    public Map<String, Object> verifyAndGetClaims(PhaasUser userDetails, String token, Map<String, Object> requiredClaims) {
+        try {
+            JWEObject jweObject = JWEObject.parse(token);
+            CryptoData cryptoData = findCryptoData(userDetails, jweObject);
+
+            Map<String, Object> actualClaims = decryptAndVerifySignature(jweObject, cryptoData).getJWTClaimsSet().getClaims();
+
+            return verifyClaims(requiredClaims, actualClaims);
+        } catch (JOSEException | ParseException | IllegalArgumentException e) {
+            throw new JWTException(e);
+        }
+    }
 
     public static class JWTException extends RuntimeException {
         JWTException(Exception e) {

--- a/src/test/java/com/github/tomitakussaari/phaas/GracefullyStopTomcatTest.java
+++ b/src/test/java/com/github/tomitakussaari/phaas/GracefullyStopTomcatTest.java
@@ -1,0 +1,33 @@
+package com.github.tomitakussaari.phaas;
+
+import com.github.tomitakussaari.phaas.GracefullyStopTomcat.GracefulShutdown;
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.ProtocolHandler;
+import org.apache.tomcat.util.threads.ThreadPoolExecutor;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.when;
+
+public class GracefullyStopTomcatTest {
+
+    private Connector connector = Mockito.mock(Connector.class);
+    private ProtocolHandler protocolHandler = Mockito.mock(ProtocolHandler.class);
+    private ThreadPoolExecutor threadPoolExecutor = Mockito.mock(ThreadPoolExecutor.class);
+
+    @Test
+    public void shutsDownTomcatGracefully() throws InterruptedException {
+        when(connector.getProtocolHandler()).thenReturn(protocolHandler);
+        when(protocolHandler.getExecutor()).thenReturn(threadPoolExecutor);
+
+        GracefulShutdown gracefulShutdown = new GracefulShutdown();
+        gracefulShutdown.customize(connector);
+
+        gracefulShutdown.onApplicationEvent(null);
+        Mockito.verify(threadPoolExecutor).awaitTermination(30, TimeUnit.SECONDS);
+        Mockito.verify(threadPoolExecutor).shutdown();
+    }
+
+}

--- a/src/test/java/com/github/tomitakussaari/phaas/model/PasswordEncodingAlgorithmTest.java
+++ b/src/test/java/com/github/tomitakussaari/phaas/model/PasswordEncodingAlgorithmTest.java
@@ -1,0 +1,49 @@
+package com.github.tomitakussaari.phaas.model;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PasswordEncodingAlgorithmTest {
+
+    @Test
+    public void findForHashReturnsEmptyForUnknown() {
+        assertFalse(PasswordEncodingAlgorithm.findForHash("foobar").isPresent());
+    }
+
+    @Test
+    public void canHashAndVerifyWithAllAlgorithms() {
+        for(PasswordEncodingAlgorithm algorithm : PasswordEncodingAlgorithm.values()) {
+            PasswordEncoder encoder = algorithm.encoder();
+            String password = "password";
+            String hash = encoder.encode(password);
+            assertTrue(algorithm+ " did not verify password", encoder.matches(password, hash));
+        }
+    }
+
+    @Test
+    public void findsCorrectEncoderForHash() {
+        for(PasswordEncodingAlgorithm algorithm : PasswordEncodingAlgorithm.values()) {
+            String password = "password";
+            String hash = algorithm.encoder().encode(password);
+            PasswordEncoder decoder = PasswordEncodingAlgorithm.findForHash(hash).get().encoder();
+            assertTrue(algorithm+ " did not verify password", decoder.matches(password, hash));
+        }
+    }
+
+
+    @Test
+    public void allAlgorithmsSupportVeryLongPasswords() {
+        for(PasswordEncodingAlgorithm algorithm : PasswordEncodingAlgorithm.values()) {
+            PasswordEncoder encoder = algorithm.encoder();
+            String password = RandomStringUtils.randomAlphabetic(120);
+            String hash = encoder.encode(password);
+            assertTrue(algorithm+ " did not verify password", encoder.matches(password, hash));
+            assertFalse(algorithm+ " did not notice difference with very long password", encoder.matches(password+"1", hash));
+        }
+    }
+
+}

--- a/src/test/java/com/github/tomitakussaari/phaas/user/UserPasswordEncoderTest.java
+++ b/src/test/java/com/github/tomitakussaari/phaas/user/UserPasswordEncoderTest.java
@@ -1,0 +1,32 @@
+package com.github.tomitakussaari.phaas.user;
+
+import com.github.tomitakussaari.phaas.model.PasswordEncodingAlgorithm;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UserPasswordEncoderTest {
+
+    private UserPasswordEncoder encoder = new UserPasswordEncoder();
+    private String password = "password";
+    @Test
+    public void hashesAndVerifiesPassword() {
+        String hash = encoder.encode(password);
+        assertTrue(encoder.matches(password, hash));
+    }
+
+    @Test
+    public void hashesNewPasswordsWithArgon2() {
+        String hash = encoder.encode(password);
+        System.out.println(hash);
+        assertEquals(PasswordEncodingAlgorithm.ARGON2, PasswordEncodingAlgorithm.findForHash(hash).get());
+    }
+
+    @Test
+    public void acceptsBCryptProtectedPassword() {
+        String hash = PasswordEncodingAlgorithm.SHA256_BCRYPT.encoder().encode(password);
+        assertTrue(encoder.matches(password, hash));
+    }
+
+}

--- a/src/test/java/com/github/tomitakussaari/phaas/user/UsersFromEnvironmentStringCreator.java
+++ b/src/test/java/com/github/tomitakussaari/phaas/user/UsersFromEnvironmentStringCreator.java
@@ -35,10 +35,8 @@ public class UsersFromEnvironmentStringCreator {
             userData.setUserConfigurationDTOs(new UserConfigurationDTO[]{userConfigurationDTO});
             return userConfigurationDTO;
         });
-        usersService.createUser("testing-user", PasswordEncodingAlgorithm.SHA256_BCRYPT, Collections.singletonList(UsersService.ROLE.USER), password, sharedSecret);
+        usersService.createUser("testing-user", PasswordEncodingAlgorithm.ARGON2, Collections.singletonList(UsersService.ROLE.USER), password, sharedSecret);
 
         System.out.println(UserData.serialize(Collections.singletonList(userData)));
-        //db.users.content= [{"userDTO":{"id":null,"userName":"testing-user","passwordHash":"$2a$10$8jH2j2uTf5AEXanJhiFvu.6sS.IDUB25AOqGIeYBwrOlFqe8XAHJm","roles":"ROLE_USER","sharedSecretForSigningCommunication":"secret"},"userConfigurationDTOs":[{"id":null,"user":"testing-user","dataProtectionKey":"da5385256044cfa6.b6c628d3bc92b404c4f7735e52cf80dbd6ad88fbece0a42f564e13d75607d922fd2231d9f309428430dffb1fdb00cf52cd5b080811d866757676509dba50ca77","active":true,"algorithm":"SHA256_BCRYPT"}]}]
-
     }
 }

--- a/src/test/java/com/github/tomitakussaari/phaas/util/JwtHelperTest.java
+++ b/src/test/java/com/github/tomitakussaari/phaas/util/JwtHelperTest.java
@@ -2,7 +2,7 @@ package com.github.tomitakussaari.phaas.util;
 
 import com.github.tomitakussaari.phaas.model.DataProtectionScheme;
 import com.github.tomitakussaari.phaas.model.DataProtectionScheme.CryptoData;
-import com.github.tomitakussaari.phaas.user.PhaasUserDetails;
+import com.github.tomitakussaari.phaas.user.PhaasUser;
 import com.github.tomitakussaari.phaas.user.UsersService;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
@@ -18,10 +18,11 @@ import static org.mockito.Mockito.when;
 
 public class JwtHelperTest {
 
-    private final PhaasUserDetails userDetails = Mockito.mock(PhaasUserDetails.class);
+    private final PhaasUser userDetails = Mockito.mock(PhaasUser.class);
     private final String secretKey = UsersService.randomKey();
     private final CryptoData cryptoData = Mockito.mock(CryptoData.class);
     private final DataProtectionScheme scheme = Mockito.mock(DataProtectionScheme.class);
+    private final JwtHelper jwtHelper = new JwtHelper();
 
     @Before
     public void before() {
@@ -36,16 +37,16 @@ public class JwtHelperTest {
     @Test
     public void generateAndParse() {
         ImmutableMap<String, Object> claims = ImmutableMap.of("claim1", "value1");
-        String token = JwtHelper.generate(userDetails, claims);
-        Map<String, Object> parsedClaims = JwtHelper.verifyAndGetClaims(userDetails, token, ImmutableMap.of());
+        String token = jwtHelper.generate(userDetails, claims);
+        Map<String, Object> parsedClaims = jwtHelper.verifyAndGetClaims(userDetails, token, ImmutableMap.of());
         assertEquals(claims.get("claim1"), parsedClaims.get("claim1"));
     }
 
     @Test
     public void setsIssuedAtIssuerAndTokenIdClaimsAutomatically() {
         ImmutableMap<String, Object> claims = ImmutableMap.of();
-        String token = JwtHelper.generate(userDetails, claims);
-        Map<String, Object> parsedClaims = JwtHelper.verifyAndGetClaims(userDetails, token, ImmutableMap.of());
+        String token = jwtHelper.generate(userDetails, claims);
+        Map<String, Object> parsedClaims = jwtHelper.verifyAndGetClaims(userDetails, token, ImmutableMap.of());
         assertNotNull(parsedClaims.get("jti"));
         assertNotNull(parsedClaims.get("iat"));
         assertEquals("my-user", parsedClaims.get("iss"));
@@ -54,9 +55,9 @@ public class JwtHelperTest {
     @Test
     public void rejectsTokensWithoutRequiredClaim() {
         ImmutableMap<String, Object> claims = ImmutableMap.of("claim1", "value1");
-        String token = JwtHelper.generate(userDetails, claims);
+        String token = jwtHelper.generate(userDetails, claims);
         try {
-            JwtHelper.verifyAndGetClaims(userDetails, token, ImmutableMap.of("claim2", "value2"));
+            jwtHelper.verifyAndGetClaims(userDetails, token, ImmutableMap.of("claim2", "value2"));
         } catch (JwtHelper.JWTException e) {
             assertEquals("Wrong value for claim2 required: value2 but was null", e.getMessage());
         }
@@ -65,9 +66,9 @@ public class JwtHelperTest {
     @Test
     public void rejectsTokensWithWrongValueForRequiredClaim() {
         ImmutableMap<String, Object> claims = ImmutableMap.of("claim1", "value1");
-        String token = JwtHelper.generate(userDetails, claims);
+        String token = jwtHelper.generate(userDetails, claims);
         try {
-            JwtHelper.verifyAndGetClaims(userDetails, token, ImmutableMap.of("claim1", "something-else"));
+            jwtHelper.verifyAndGetClaims(userDetails, token, ImmutableMap.of("claim1", "something-else"));
             fail("should not have succeeded");
         } catch (JwtHelper.JWTException e) {
             assertEquals("Wrong value for claim1 required: something-else but was value1", e.getMessage());
@@ -79,7 +80,7 @@ public class JwtHelperTest {
         when(cryptoData.dataProtectionKey()).thenReturn("CJ;h*ywnWV4t9_+BN?~]}&P~E8uEAme@");
         String oldToken = "eyJ6aXAiOiJERUYiLCJraWQiOiIxIiwiY3R5IjoiSldUIiwiZW5jIjoiQTI1NkdDTSIsImFsZyI6ImRpciJ9..auZ902bJ1qNGS0P-.UO1SFi3qtsknfORNjL5Hp0bq1nzy4TpCOHzI7K-gtoKrTC5xVqkJB-kOzB_lnPnYsYo2x_Z375T5HVRa8N9uxoFUvx0naDDznKwvt3CvgiWqEgA4E0Hyg4EyqMKiazVKeN9zpH-cMtd6VjCcziXfXBi_iMhvUyeZMJANZUg1BfgOU0K1cjR_jc_LrRiMv7Bcy0Y3ygV2NheiNULqBj5Ob6xg8trgoIp_-F5NbQ.vzIhXbpCESR4EjGekJEQgA";
         ImmutableMap<String, Object> claims = ImmutableMap.of("claim1", "value1");
-        JwtHelper.verifyAndGetClaims(userDetails, oldToken, claims);
+        jwtHelper.verifyAndGetClaims(userDetails, oldToken, claims);
     }
 
     @Test
@@ -88,7 +89,7 @@ public class JwtHelperTest {
         String oldToken = "eyJ6aXAiOiJERUYiLCJraWQiOiIxIiwiY3R5IjoiSldUIiwiZW5jIjoiQTI1NkdDTSIsImFsZyI6ImRpciJ9..auZ902bJ1qNGS0P-.UO1SFi3qtsknfORNjL5Hp0bq1nzy4TpCOHzI7K-gtoKrTC5xVqkJB-kOzB_lnPnYsYo2x_Z375T5HVRa8N9uxoFUvx0naDDznKwvt3CvgiWqEgA4E0Hyg4EyqMKiazVKeN9zpH-cMtd6VjCcziXfXBi_iMhvUyeZMJANZUg1BfgOU0K1cjR_jc_LrRiMv7Bcy0Y3ygV2NheiNULqBj5Ob6xg8trgoIp_-F5NbQ.vzIhXbpCESR4EjGekJEQgA";
         ImmutableMap<String, Object> claims = ImmutableMap.of("claim1", "value1");
         try {
-            JwtHelper.verifyAndGetClaims(userDetails, oldToken, claims);
+            jwtHelper.verifyAndGetClaims(userDetails, oldToken, claims);
             fail("should not have succeeded");
         } catch (JwtHelper.JWTException e) {
             assertEquals("AES/GCM/NoPadding decryption failed: Tag mismatch!", e.getMessage());

--- a/src/test/java/com/github/tomitakussaari/phaas/util/PasswordVerifierTest.java
+++ b/src/test/java/com/github/tomitakussaari/phaas/util/PasswordVerifierTest.java
@@ -19,8 +19,8 @@ public class PasswordVerifierTest {
     private final String encryptionKeyTwo= "encryption_key2";
     private final DataProtectionScheme currentDataProtectionScheme = new DataProtectionScheme(1, PasswordEncodingAlgorithm.SHA256_BCRYPT, salt+"."+Encryptors.text(password, salt).encrypt(encryptionKey));
     private final DataProtectionScheme newDataProtectionScheme = new DataProtectionScheme(1, PasswordEncodingAlgorithm.SHA256_BCRYPT, salt+"."+Encryptors.text(password, salt).encrypt(encryptionKeyTwo));
-    private final DataProtectionScheme.CryptoData decryptedCurrentProtectionScheme = currentDataProtectionScheme.decryptedProtectionScheme(password);
-    private final DataProtectionScheme.CryptoData decryptedNewProtectionScheme = newDataProtectionScheme.decryptedProtectionScheme(password);
+    private final DataProtectionScheme.CryptoData decryptedCurrentProtectionScheme = currentDataProtectionScheme.cryptoData(password);
+    private final DataProtectionScheme.CryptoData decryptedNewProtectionScheme = newDataProtectionScheme.cryptoData(password);
 
     @Test
     public void doesNotReturnRehashedPasswordWhenActiveSchemeIsSameAsCurrent() {


### PR DESCRIPTION
Argon2 won password hashing competition in 2015 (https://github.com/P-H-C/phc-winner-argon2),
and it should be around the best way to hash passwords out there.

Bad thing is that there are no native java implementations, atleast yet, so we have to use Java Native Access,
which could be problematic in some environments, so leave sha+bcrypt solution still there..

https://github.com/phxql/argon2-jvm